### PR TITLE
Feature/ssd manager

### DIFF
--- a/SSDManager/SSDManager.cpp
+++ b/SSDManager/SSDManager.cpp
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <vector>
+#include <stdexcept>
 
 class SSDManager {
  public:
@@ -9,6 +10,57 @@ class SSDManager {
         for (int i = 0; i < argc; i++) {
             parsed_command.push_back(argv[i]);
         }
+    }
+
+    bool isValidInput() {
+        int argc = parsed_command.size();
+        if (argc < 2) {
+            return false;
+        }
+
+        std::string& cmd = parsed_command[1];
+        if (cmd != "W" && cmd != "R") {
+            return false;
+        }
+
+        if (argc < 3) {
+            return false;
+        }
+
+        std::string& index = parsed_command[2];
+        try {
+            if (stoi(index) < 0 || stoi(index) > 99) {
+                return false;
+            }
+        }
+        catch (std::exception& e) {  // stoi() fail
+            return false;
+        }
+
+        if (cmd == "W") {
+            if (argc != 4) {
+                return false;
+            }
+
+            std::string& value = parsed_command[3];
+            if (value.length() != 10) {
+                return false;
+            }
+            if (value.substr(0, 2) != "0x") {
+                return false;
+            }
+            for (char& c : value.substr(2, 8)) {
+                if (c < '0' || (c > '9' && c < 'A') || c > 'F') {
+                    return false;
+                }
+            }
+        }
+
+        if (cmd == "R" && argc != 3) {
+            return false;
+        }
+
+        return true;
     }
 
     std::vector<std::string> getParsedCommand() {

--- a/SSDManager/SSDManager.cpp
+++ b/SSDManager/SSDManager.cpp
@@ -1,0 +1,20 @@
+/* Copyright 2024 Code Love you */
+
+#include <string>
+#include <vector>
+
+class SSDManager {
+ public:
+    SSDManager(int argc, char** argv) {
+        for (int i = 0; i < argc; i++) {
+            parsed_command.push_back(argv[i]);
+        }
+    }
+
+    std::vector<std::string> getParsedCommand() {
+        return parsed_command;
+    }
+
+ private:
+    std::vector<std::string> parsed_command;
+};

--- a/SSDManager/SSDManager.cpp
+++ b/SSDManager/SSDManager.cpp
@@ -8,26 +8,58 @@ class SSDManager {
  public:
     SSDManager(int argc, char** argv) {
         for (int i = 0; i < argc; i++) {
-            parsed_command.push_back(argv[i]);
+            parsed_input.push_back(argv[i]);
         }
     }
 
     bool isValidInput() {
-        int argc = parsed_command.size();
+        int argc = parsed_input.size();
+
+        if (isValidCommand(argc) == false) {
+            return false;
+        }
+
+        if (isValidIndex(argc) == false) {
+            return false;
+        }
+
+        if (isValidWriteInput(argc) == false) {
+            return false;
+        }
+
+        if (isValidReadInput(argc) == false) {
+            return false;
+        }
+
+        return true;
+    }
+
+    std::vector<std::string> getParsedCommand() {
+        return parsed_input;
+    }
+
+ private:
+    std::vector<std::string> parsed_input;
+
+    bool isValidCommand(int argc) {
         if (argc < 2) {
             return false;
         }
 
-        std::string& cmd = parsed_command[1];
+        std::string cmd = parsed_input[1];
         if (cmd != "W" && cmd != "R") {
             return false;
         }
 
+        return true;
+    }
+
+    bool isValidIndex(int argc) {
         if (argc < 3) {
             return false;
         }
 
-        std::string& index = parsed_command[2];
+        std::string& index = parsed_input[2];
         try {
             if (stoi(index) < 0 || stoi(index) > 99) {
                 return false;
@@ -37,12 +69,28 @@ class SSDManager {
             return false;
         }
 
+        return true;
+    }
+
+    bool isValidReadInput(int argc) {
+        std::string cmd = parsed_input[1];
+
+        if (cmd == "R" && argc != 3) {
+            return false;
+        }
+
+        return true;
+    }
+
+    bool isValidWriteInput(int argc) {
+        std::string cmd = parsed_input[1];
+
         if (cmd == "W") {
             if (argc != 4) {
                 return false;
             }
 
-            std::string& value = parsed_command[3];
+            std::string& value = parsed_input[3];
             if (value.length() != 10) {
                 return false;
             }
@@ -56,17 +104,6 @@ class SSDManager {
             }
         }
 
-        if (cmd == "R" && argc != 3) {
-            return false;
-        }
-
         return true;
     }
-
-    std::vector<std::string> getParsedCommand() {
-        return parsed_command;
-    }
-
- private:
-    std::vector<std::string> parsed_command;
 };

--- a/SSDManagerTest/SSDManagerTest.cpp
+++ b/SSDManagerTest/SSDManagerTest.cpp
@@ -1,9 +1,20 @@
+/* Copyright 2024 Code Love you */
+
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
-
 #include "../SSDManager/SSDManager.cpp"
 
-TEST(SSDManagerTest, TestCase) {
-	EXPECT_EQ(1, 1);
-	EXPECT_TRUE(true);
+using namespace std;
+
+TEST(SSDManagerTest, constructorTest) {
+    // Arrange
+    int argc = 4;
+    char* argv[] = {"ssd", "W", "2", "0x1298CDEF"};
+    vector<string> expected = { "ssd", "W", "2", "0x1298CDEF" };
+
+    // Act
+    SSDManager ssd(argc, argv);
+
+    // Assert
+    EXPECT_EQ(ssd.getParsedCommand(), expected);
 }

--- a/SSDManagerTest/SSDManagerTest.cpp
+++ b/SSDManagerTest/SSDManagerTest.cpp
@@ -18,3 +18,103 @@ TEST(SSDManagerTest, constructorTest) {
     // Assert
     EXPECT_EQ(ssd.getParsedCommand(), expected);
 }
+
+TEST(SSDManagerTest, validOkayTest) {
+    // Arrange
+    int argc = 4;
+    char* argv[] = { "ssd", "W", "2", "0x1298CDEF" };
+    SSDManager ssd(argc, argv);
+
+    // Act, Assert
+    EXPECT_EQ(ssd.isValidInput(), true);
+}
+
+TEST(SSDManagerTest, validFailTest1) {
+    // Arrange
+    int argc = 1;
+    char* argv[] = { "ssd" };
+    SSDManager ssd(argc, argv);
+
+    // Act, Assert
+    EXPECT_EQ(ssd.isValidInput(), false);
+}
+
+TEST(SSDManagerTest, validFailTest2) {
+    // Arrange
+    int argc = 4;
+    char* argv[] = { "ssd", "Write", "2", "0x1298CDEF" };
+    SSDManager ssd(argc, argv);
+
+    // Act, Assert
+    EXPECT_EQ(ssd.isValidInput(), false);
+}
+
+TEST(SSDManagerTest, validFailTest3) {
+    // Arrange
+    int argc = 4;
+    char* argv[] = { "ssd", "W", "ABC", "0x1298CDEF" };
+    SSDManager ssd(argc, argv);
+
+    // Act, Assert
+    EXPECT_EQ(ssd.isValidInput(), false);
+}
+
+TEST(SSDManagerTest, validFailTest4) {
+    // Arrange
+    int argc = 4;
+    char* argv[] = { "ssd", "W", "100", "0x1298CDEF" };
+    SSDManager ssd(argc, argv);
+
+    // Act, Assert
+    EXPECT_EQ(ssd.isValidInput(), false);
+}
+
+TEST(SSDManagerTest, validFailTest5) {
+    // Arrange
+    int argc = 3;
+    char* argv[] = { "ssd", "W", "2" };
+    SSDManager ssd(argc, argv);
+
+    // Act, Assert
+    EXPECT_EQ(ssd.isValidInput(), false);
+}
+
+TEST(SSDManagerTest, validFailTest6) {
+    // Arrange
+    int argc = 4;
+    char* argv[] = { "ssd", "W", "2", "0x1234ABCD1234ABCD"};
+    SSDManager ssd(argc, argv);
+
+    // Act, Assert
+    EXPECT_EQ(ssd.isValidInput(), false);
+}
+
+TEST(SSDManagerTest, validFailTest7) {
+    // Arrange
+    int argc = 4;
+    char* argv[] = { "ssd", "W", "2", "1234ABCD1234ABCD" };
+    SSDManager ssd(argc, argv);
+
+    // Act, Assert
+    EXPECT_EQ(ssd.isValidInput(), false);
+}
+
+TEST(SSDManagerTest, validFailTes8) {
+    // Arrange
+    int argc = 4;
+    char* argv[] = { "ssd", "W", "2", "0xABCDEFGH" };
+    SSDManager ssd(argc, argv);
+
+    // Act, Assert
+    EXPECT_EQ(ssd.isValidInput(), false);
+}
+
+TEST(SSDManagerTest, validFailTes9) {
+    // Arrange
+    int argc = 4;
+    char* argv[] = { "ssd", "R", "2", "0xABCDEFGH" };
+    SSDManager ssd(argc, argv);
+
+    // Act, Assert
+    EXPECT_EQ(ssd.isValidInput(), false);
+}


### PR DESCRIPTION
## 구현 내용
SSD가 main을 통해 실행될 때, argc와 argv를 SSDManager 생성자에 전달해준다고 생각하고 개발 진행하였습니다.
char** argv를 vector<string> 형태로 넣어주고 유효한 Input인지 확인하였습니다.

코치님께 문의했을 때 대소문자 관계 없이 처리할 수 있게 구현해도 되고
대문자만 처리하도록 구현해도 된다고 해서
일단 대문자만 처리하도록 구현했습니다. (소문자로 Input이 들어오면 Fail)

## 테스트 결과
```cpp
[==========] Running 12 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 1 test from FileManagerTest
[ RUN      ] FileManagerTest.TestCase
[       OK ] FileManagerTest.TestCase (0 ms)
[----------] 1 test from FileManagerTest (0 ms total)

[----------] 11 tests from SSDManagerTest
[ RUN      ] SSDManagerTest.constructorTest
[       OK ] SSDManagerTest.constructorTest (0 ms)
[ RUN      ] SSDManagerTest.validOkayTest
[       OK ] SSDManagerTest.validOkayTest (0 ms)
[ RUN      ] SSDManagerTest.validFailTest1
[       OK ] SSDManagerTest.validFailTest1 (0 ms)
[ RUN      ] SSDManagerTest.validFailTest2
[       OK ] SSDManagerTest.validFailTest2 (0 ms)
[ RUN      ] SSDManagerTest.validFailTest3
[       OK ] SSDManagerTest.validFailTest3 (0 ms)
[ RUN      ] SSDManagerTest.validFailTest4
[       OK ] SSDManagerTest.validFailTest4 (0 ms)
[ RUN      ] SSDManagerTest.validFailTest5
[       OK ] SSDManagerTest.validFailTest5 (0 ms)
[ RUN      ] SSDManagerTest.validFailTest6
[       OK ] SSDManagerTest.validFailTest6 (0 ms)
[ RUN      ] SSDManagerTest.validFailTest7
[       OK ] SSDManagerTest.validFailTest7 (0 ms)
[ RUN      ] SSDManagerTest.validFailTes8
[       OK ] SSDManagerTest.validFailTes8 (0 ms)
[ RUN      ] SSDManagerTest.validFailTes9
[       OK ] SSDManagerTest.validFailTes9 (0 ms)
[----------] 11 tests from SSDManagerTest (3 ms total)
[----------] Global test environment tear-down
[==========] 12 tests from 2 test suites ran. (4 ms total)
[  PASSED  ] 12 tests.
```

## cpplint 결과
```bash
PS C:\Users\user\source\repos\SSDTestShell\SSDTestShell\SSDManager> cpplint SSDManager.cpp
Done processing SSDManager.cpp

PS C:\Users\user\source\repos\SSDTestShell\SSDTestShell\SSDManagerTest> cpplint SSDManagerTest.cpp
SSDManagerTest.cpp:5:  Do not include .cpp files from other packages  [build/include] [4]
SSDManagerTest.cpp:7:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces] [5]
Done processing SSDManagerTest.cpp
Total errors found: 2
```