### PR TITLE
[fix] Change FileManager class method and update its interface

### DIFF
--- a/SSDManager/FileManager.cpp
+++ b/SSDManager/FileManager.cpp
@@ -7,26 +7,28 @@
 FileManager::FileManager() {
 }
 
-std::fstream* FileManager::init(std::string name) {
-    return nullptr;
+bool FileManager::init(std::string name) {
+    return true;
 }
 
-std::fstream * FileManager::open(std::string) {
-    return nullptr;
+bool FileManager::open(std::string name) {
+    return true;
 }
 
-unsigned int FileManager::read(std::fstream* fs, int index) {
+bool FileManager::close(std::string name) {
+    return true;
+}
+
+unsigned int FileManager::read(std::string name, int index) {
     return 0;
 }
 
-bool FileManager::write(std::fstream* fs, int index, unsigned int value) {
+bool FileManager::write(std::string name, int index, unsigned int value) {
     return true;
 }
 
-bool FileManager::write(std::fstream* fs, unsigned int value) {
+bool FileManager::write(std::string name, unsigned int value) {
     return true;
 }
 
-bool FileManager::close(std::fstream* fs) {
-    return true;
-}
+

--- a/SSDManager/FileManager.cpp
+++ b/SSDManager/FileManager.cpp
@@ -19,16 +19,28 @@ bool FileManager::close(std::string name) {
     return true;
 }
 
-unsigned int FileManager::read(std::string name, int index) {
-    return 0;
+std::string FileManager::read(std::string name, int index) {
+    return "";
 }
 
-bool FileManager::write(std::string name, int index, unsigned int value) {
+bool FileManager::write(std::string name, int index, std::string value) {
+    
+    nandFile.open("nand.txt", std::ios::out | std::ios::in | std::ios::ate);
+    
+    if (nandFile.is_open())
+    {
+        return true;
+    }
+    else
+    {
+        std::cout << "Open Failed\n";
+        /* TO DO : implement exception with throw */
+        return false;
+    }
+    nandFile.close();
     return true;
 }
 
-bool FileManager::write(std::string name, unsigned int value) {
+bool FileManager::write(std::string name, std::string value) {
     return true;
 }
-
-

--- a/SSDManager/FileManager.h
+++ b/SSDManager/FileManager.h
@@ -11,12 +11,14 @@ public:
     bool init(std::string name);
     bool open(std::string name);
     bool close(std::string name);
-    unsigned int read(std::string name, int index);
-    bool write(std::string name, int index, unsigned int value);
-    bool write(std::string name, unsigned int value);
+    std::string read(std::string name, int index);
+    bool write(std::string name, int index, std::string value);
+    bool write(std::string name, std::string value);
 private:
     const std::string EMPTY = "0x00000000";
     const int MAX_SIZE = 100;
+    std::fstream nandFile;
+    std::fstream resultFile;
     const std::string RESULT = "result.txt";
-    const std::string nand = "nand.txt";
+    const std::string NAND = "nand.txt";
 };

--- a/SSDManager/FileManager.h
+++ b/SSDManager/FileManager.h
@@ -1,15 +1,22 @@
+/* Copyright 2024 Code Love you */
 #pragma once
 #include <iostream>
 #include <fstream>
 #include <string>
+#include "FileManagerInterface.h"
 
-class FileManager {
+class FileManager : public FileManagerInterface {
 public:
     FileManager();
-    std::fstream* init(std::string name);
-    std::fstream* open(std::string name);
-    unsigned int read(std::fstream* fs, int index);
-    bool write(std::fstream* fs, int index, unsigned int value);
-    bool write(std::fstream* fs, unsigned int value);
-    bool close(std::fstream* fs);
+    bool init(std::string name);
+    bool open(std::string name);
+    bool close(std::string name);
+    unsigned int read(std::string name, int index);
+    bool write(std::string name, int index, unsigned int value);
+    bool write(std::string name, unsigned int value);
+private:
+    const std::string EMPTY = "0x00000000";
+    const int MAX_SIZE = 100;
+    const std::string RESULT = "result.txt";
+    const std::string nand = "nand.txt";
 };

--- a/SSDManager/FileManagerInterface.h
+++ b/SSDManager/FileManagerInterface.h
@@ -1,0 +1,13 @@
+/* Copyright 2024 Code Love you */
+#pragma once
+#include <string>
+
+class FileManagerInterface {
+public:
+    virtual bool init(std::string name) = 0;
+    virtual bool open(std::string name) = 0;
+    virtual bool close(std::string name) = 0;
+    virtual unsigned int read(std::string name, int index) = 0;
+    virtual bool write(std::string name, int index, unsigned int value) = 0;;
+    virtual bool write(std::string name, unsigned int value) = 0;
+};

--- a/SSDManager/FileManagerInterface.h
+++ b/SSDManager/FileManagerInterface.h
@@ -7,7 +7,7 @@ public:
     virtual bool init(std::string name) = 0;
     virtual bool open(std::string name) = 0;
     virtual bool close(std::string name) = 0;
-    virtual unsigned int read(std::string name, int index) = 0;
-    virtual bool write(std::string name, int index, unsigned int value) = 0;;
-    virtual bool write(std::string name, unsigned int value) = 0;
+    virtual std::string read(std::string name, int index) = 0;
+    virtual bool write(std::string name, int index, std::string value) = 0;;
+    virtual bool write(std::string name, std::string value) = 0;
 };

--- a/SSDManager/SSDManager.vcxproj
+++ b/SSDManager/SSDManager.vcxproj
@@ -131,6 +131,10 @@
     <ClCompile Include="main.cpp" />
     <ClCompile Include="SSDManager.cpp" />
   </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="FileManager.h" />
+    <ClInclude Include="FileManagerInterface.h" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/SSDManager/SSDManager.vcxproj.filters
+++ b/SSDManager/SSDManager.vcxproj.filters
@@ -25,4 +25,12 @@
       <Filter>소스 파일</Filter>
     </ClCompile>
   </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="FileManager.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="FileManagerInterface.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+  </ItemGroup>
 </Project>

--- a/SSDManagerTest/FileManagerTest.cpp
+++ b/SSDManagerTest/FileManagerTest.cpp
@@ -4,7 +4,6 @@
 #include "gmock/gmock.h"
 #include "../SSDManager/FileManager.cpp"
 #include "../SSDManager/FileManagerInterface.h"
-#include <string>
 
 #define TEST_INDEX  (0)
 #define TEST_VALUE  ("0xAAAAAAAA")

--- a/SSDManagerTest/FileManagerTest.cpp
+++ b/SSDManagerTest/FileManagerTest.cpp
@@ -7,13 +7,18 @@
 #include <string>
 
 #define TEST_INDEX  (0)
-#define TEST_VALUE  (0xAAAAAAAA)
+#define TEST_VALUE  ("0xAAAAAAAA")
 
 #define TEST_RESULT ("result.txt")
 #define TEST_NAND   ("nand.txt")
 
 using namespace std;
 using namespace testing;
+
+class FileManagerMock : public FileManager {
+public:
+    MOCK_METHOD(bool, write, (string, int, string), ());
+};
 
 TEST(FileManagerTest, file_manager_test_init) {
     FileManager fm;
@@ -32,15 +37,18 @@ TEST(FileManagerTest, file_manager_test_close) {
 }
 TEST(FileManagerTest, file_manager_test_read) {
     FileManager fm;
-    EXPECT_THAT(fm.read(TEST_RESULT, TEST_INDEX), 0);
+    EXPECT_THAT(fm.read(TEST_RESULT, TEST_INDEX), "");
 }
 
 TEST(FileManagerTest, file_manager_test_write) {
     FileManager fm;
-    EXPECT_THAT(fm.write(TEST_RESULT, TEST_INDEX), true);
+    FileManagerMock fmMock;
+    EXPECT_CALL(fmMock, write(TEST_NAND, TEST_INDEX, TEST_VALUE))
+        .WillOnce(Return(true));
+    EXPECT_EQ(fmMock.write(TEST_NAND, TEST_INDEX, TEST_VALUE), true);
 }
 
 TEST(FileManagerTest, file_manager_test_write_during_read) {
     FileManager fm;
-    EXPECT_THAT(fm.write(TEST_RESULT, TEST_INDEX), true);
+    EXPECT_THAT(fm.write(TEST_RESULT, TEST_VALUE), true);
 }

--- a/SSDManagerTest/FileManagerTest.cpp
+++ b/SSDManagerTest/FileManagerTest.cpp
@@ -3,42 +3,44 @@
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 #include "../SSDManager/FileManager.cpp"
+#include "../SSDManager/FileManagerInterface.h"
+#include <string>
 
 #define TEST_INDEX  (0)
 #define TEST_VALUE  (0xAAAAAAAA)
 
+#define TEST_RESULT ("result.txt")
+#define TEST_NAND   ("nand.txt")
+
 using namespace std;
+using namespace testing;
 
 TEST(FileManagerTest, file_manager_test_init) {
     FileManager fm;
-    EXPECT_THAT(fm.init("test.txt"), testing::IsNull());
+    EXPECT_THAT(fm.init(TEST_RESULT), true);
 }
 
 TEST(FileManagerTest, file_manager_test_open) {
     FileManager fm;
-    EXPECT_THAT(fm.open("test.txt"), testing::IsNull());
-}
-
-TEST(FileManagerTest, file_manager_test_read) {
-    FileManager fm;
-    fstream * fs = fm.open("test.txt");
-    EXPECT_THAT(fm.read(fs, TEST_INDEX), 0);
-}
-
-TEST(FileManagerTest, file_manager_test_write) {
-    FileManager fm;
-    fstream* fs = fm.open("test.txt");
-    EXPECT_THAT(fm.write(fs, TEST_INDEX, TEST_VALUE), true);
-}
-
-TEST(FileManagerTest, file_manager_test_write_during_read) {
-    FileManager fm;
-    fstream* fs = fm.open("test.txt");
-    EXPECT_THAT(fm.write(fs, TEST_VALUE), true);
+    EXPECT_THAT(fm.open(TEST_RESULT), true);
 }
 
 TEST(FileManagerTest, file_manager_test_close) {
     FileManager fm;
-    fstream* fs = fm.open("test.txt");
-    EXPECT_THAT(fm.close(fs), true);
+    EXPECT_THAT(fm.close(TEST_RESULT), true);
+
+}
+TEST(FileManagerTest, file_manager_test_read) {
+    FileManager fm;
+    EXPECT_THAT(fm.read(TEST_RESULT, TEST_INDEX), 0);
+}
+
+TEST(FileManagerTest, file_manager_test_write) {
+    FileManager fm;
+    EXPECT_THAT(fm.write(TEST_RESULT, TEST_INDEX), true);
+}
+
+TEST(FileManagerTest, file_manager_test_write_during_read) {
+    FileManager fm;
+    EXPECT_THAT(fm.write(TEST_RESULT, TEST_INDEX), true);
 }


### PR DESCRIPTION
# Back ground
Architecture is changed, so update filemanager
with changing method parameter and create its interface.

Also, as method is changed, unit test is also updated.

# Test Result

Test result is as below:
```
Running main() from C:\Users\User\source\repos\SSDTestShell\packages\gmock.1.11.0\lib\native\src\gtest\src\gtest_main.cc
[==========] Running 7 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 6 tests from FileManagerTest
[ RUN      ] FileManagerTest.file_manager_test_init
[       OK ] FileManagerTest.file_manager_test_init (0 ms)
[ RUN      ] FileManagerTest.file_manager_test_open
[       OK ] FileManagerTest.file_manager_test_open (0 ms)
[ RUN      ] FileManagerTest.file_manager_test_close
[       OK ] FileManagerTest.file_manager_test_close (0 ms)
[ RUN      ] FileManagerTest.file_manager_test_read
[       OK ] FileManagerTest.file_manager_test_read (0 ms)
[ RUN      ] FileManagerTest.file_manager_test_write
[       OK ] FileManagerTest.file_manager_test_write (0 ms)
[ RUN      ] FileManagerTest.file_manager_test_write_during_read
[       OK ] FileManagerTest.file_manager_test_write_during_read (0 ms)
[----------] 6 tests from FileManagerTest (2 ms total)
```
