### PR TITLE
Feature/ssd manager

### DIFF
--- a/SSDManager/SSDManager.cpp
+++ b/SSDManager/SSDManager.cpp
@@ -3,6 +3,9 @@
 #include <string>
 #include <vector>
 #include <stdexcept>
+//#include "FileManager.h"
+//#include "SSDWriter.h"
+//#include "SSDReader.h"
 
 class SSDManager {
  public:
@@ -10,7 +13,18 @@ class SSDManager {
         for (int i = 0; i < argc; i++) {
             parsed_input.push_back(argv[i]);
         }
+
+        //// TODO: Factory Pattern
+        //file_manager = new FileManager();
+        //ssd_writer = new SSDWriter(file_manager);
+        //ssd_reader = new SSDReader(file_manager);
     }
+
+    //~SSDManager() {
+    //    delete file_manager;
+    //    delete ssd_writer;
+    //    delete ssd_reader;
+    //}
 
     bool isValidInput() {
         int argc = parsed_input.size();
@@ -34,12 +48,38 @@ class SSDManager {
         return true;
     }
 
+    //bool executeCommand() {
+    //    if (isValidInput() == false) {
+    //        return false;
+    //    }
+
+    //    std::string& cmd = parsed_input[1];
+    //    int index = convertIndexInt();
+
+    //    if (cmd == "R") {
+    //        return ssd_reader.read(NAND_FILE, RESULT_FILE, index);
+    //    }
+
+    //    if (cmd == "W") {
+    //        std::string& value = parsed_input[3];
+    //        return ssd_writer.write(NAND_FILE, index, value);
+    //    }
+    //}
+
     std::vector<std::string> getParsedCommand() {
         return parsed_input;
     }
 
+
  private:
     std::vector<std::string> parsed_input;
+
+    //FileManager* file_manager;
+    //SSDWriter* ssd_writer;
+    //SSDReader* ssd_reader;
+
+    const std::string NAND_FILE = "nand.txt";
+    const std::string RESULT_FILE = "result.txt";
 
     bool isValidCommand(int argc) {
         if (argc < 2) {
@@ -73,7 +113,7 @@ class SSDManager {
     }
 
     bool isValidReadInput(int argc) {
-        std::string cmd = parsed_input[1];
+        std::string& cmd = parsed_input[1];
 
         if (cmd == "R" && argc != 3) {
             return false;
@@ -83,7 +123,7 @@ class SSDManager {
     }
 
     bool isValidWriteInput(int argc) {
-        std::string cmd = parsed_input[1];
+        std::string& cmd = parsed_input[1];
 
         if (cmd == "W") {
             if (argc != 4) {
@@ -105,5 +145,9 @@ class SSDManager {
         }
 
         return true;
+    }
+
+    int convertIndexInt() {
+        return stoi(parsed_input[2]);
     }
 };

--- a/SSDManager/SSDManager.cpp
+++ b/SSDManager/SSDManager.cpp
@@ -1,6 +1,5 @@
 /* Copyright 2024 Code Love you */
 
-#include <stdexcept>
 #include "SSDManager.h"
 
 SSDManager::SSDManager(int argc, char** argv) {
@@ -83,12 +82,14 @@ bool SSDManager::isValidIndex(int argc) {
     }
 
     std::string& index = parsed_input[2];
-    try {
-        if (stoi(index) < 0 || stoi(index) > 99) {
+
+    for (char& c : index) {
+        if (std::isdigit(c) == false) {
             return false;
         }
     }
-    catch (std::exception& e) {  // stoi() fail
+
+    if (stoi(index) < 0 || stoi(index) > 99) {
         return false;
     }
 
@@ -121,7 +122,7 @@ bool SSDManager::isValidWriteInput(int argc) {
             return false;
         }
         for (char& c : value.substr(2, 8)) {
-            if (c < '0' || (c > '9' && c < 'A') || c > 'F') {
+            if (std::isxdigit(c) == false) {
                 return false;
             }
         }

--- a/SSDManager/SSDManager.cpp
+++ b/SSDManager/SSDManager.cpp
@@ -1,153 +1,136 @@
 /* Copyright 2024 Code Love you */
 
-#include <string>
-#include <vector>
 #include <stdexcept>
-//#include "FileManager.h"
-//#include "SSDWriter.h"
-//#include "SSDReader.h"
+#include "SSDManager.h"
 
-class SSDManager {
- public:
-    SSDManager(int argc, char** argv) {
-        for (int i = 0; i < argc; i++) {
-            parsed_input.push_back(argv[i]);
-        }
-
-        //// TODO: Factory Pattern
-        //file_manager = new FileManager();
-        //ssd_writer = new SSDWriter(file_manager);
-        //ssd_reader = new SSDReader(file_manager);
+SSDManager::SSDManager(int argc, char** argv) {
+    for (int i = 0; i < argc; i++) {
+        parsed_input.push_back(argv[i]);
     }
 
-    //~SSDManager() {
-    //    delete file_manager;
-    //    delete ssd_writer;
-    //    delete ssd_reader;
-    //}
+    //// TODO: Factory Pattern
+    //file_manager = new FileManager();
+    //ssd_writer = new SSDWriter(file_manager);
+    //ssd_reader = new SSDReader(file_manager);
+}
 
-    bool isValidInput() {
-        int argc = parsed_input.size();
+//SSDManager::~SSDManager() {
+//    delete file_manager;
+//    delete ssd_writer;
+//    delete ssd_reader;
+//}
 
-        if (isValidCommand(argc) == false) {
-            return false;
-        }
+bool SSDManager::isValidInput() {
+    int argc = (int)parsed_input.size();
 
-        if (isValidIndex(argc) == false) {
-            return false;
-        }
-
-        if (isValidWriteInput(argc) == false) {
-            return false;
-        }
-
-        if (isValidReadInput(argc) == false) {
-            return false;
-        }
-
-        return true;
+    if (isValidCommand(argc) == false) {
+        return false;
     }
 
-    //bool executeCommand() {
-    //    if (isValidInput() == false) {
-    //        return false;
-    //    }
-
-    //    std::string& cmd = parsed_input[1];
-    //    int index = convertIndexInt();
-
-    //    if (cmd == "R") {
-    //        return ssd_reader.read(NAND_FILE, RESULT_FILE, index);
-    //    }
-
-    //    if (cmd == "W") {
-    //        std::string& value = parsed_input[3];
-    //        return ssd_writer.write(NAND_FILE, index, value);
-    //    }
-    //}
-
-    std::vector<std::string> getParsedCommand() {
-        return parsed_input;
+    if (isValidIndex(argc) == false) {
+        return false;
     }
 
-
- private:
-    std::vector<std::string> parsed_input;
-
-    //FileManager* file_manager;
-    //SSDWriter* ssd_writer;
-    //SSDReader* ssd_reader;
-
-    const std::string NAND_FILE = "nand.txt";
-    const std::string RESULT_FILE = "result.txt";
-
-    bool isValidCommand(int argc) {
-        if (argc < 2) {
-            return false;
-        }
-
-        std::string cmd = parsed_input[1];
-        if (cmd != "W" && cmd != "R") {
-            return false;
-        }
-
-        return true;
+    if (isValidWriteInput(argc) == false) {
+        return false;
     }
 
-    bool isValidIndex(int argc) {
-        if (argc < 3) {
+    if (isValidReadInput(argc) == false) {
+        return false;
+    }
+
+    return true;
+}
+
+//bool SSDManager::executeCommand() {
+//    if (isValidInput() == false) {
+//        return false;
+//    }
+
+//    std::string& cmd = parsed_input[1];
+//    int index = convertIndexInt();
+
+//    if (cmd == "R") {
+//        return ssd_reader.read(NAND_FILE, RESULT_FILE, index);
+//    }
+
+//    if (cmd == "W") {
+//        std::string& value = parsed_input[3];
+//        return ssd_writer.write(NAND_FILE, index, value);
+//    }
+//}
+
+std::vector<std::string> SSDManager::getParsedCommand() {
+    return parsed_input;
+}
+
+bool SSDManager::isValidCommand(int argc) {
+    if (argc < 2) {
+        return false;
+    }
+
+    std::string cmd = parsed_input[1];
+    if (cmd != "W" && cmd != "R") {
+        return false;
+    }
+
+    return true;
+}
+
+bool SSDManager::isValidIndex(int argc) {
+    if (argc < 3) {
+        return false;
+    }
+
+    std::string& index = parsed_input[2];
+    try {
+        if (stoi(index) < 0 || stoi(index) > 99) {
+            return false;
+        }
+    }
+    catch (std::exception& e) {  // stoi() fail
+        return false;
+    }
+
+    return true;
+}
+
+bool SSDManager::isValidReadInput(int argc) {
+    std::string& cmd = parsed_input[1];
+
+    if (cmd == "R" && argc != 3) {
+        return false;
+    }
+
+    return true;
+}
+
+bool SSDManager::isValidWriteInput(int argc) {
+    std::string& cmd = parsed_input[1];
+
+    if (cmd == "W") {
+        if (argc != 4) {
             return false;
         }
 
-        std::string& index = parsed_input[2];
-        try {
-            if (stoi(index) < 0 || stoi(index) > 99) {
+        std::string& value = parsed_input[3];
+        if (value.length() != 10) {
+            return false;
+        }
+        if (value.substr(0, 2) != "0x") {
+            return false;
+        }
+        for (char& c : value.substr(2, 8)) {
+            if (c < '0' || (c > '9' && c < 'A') || c > 'F') {
                 return false;
             }
         }
-        catch (std::exception& e) {  // stoi() fail
-            return false;
-        }
-
-        return true;
     }
 
-    bool isValidReadInput(int argc) {
-        std::string& cmd = parsed_input[1];
+    return true;
+}
 
-        if (cmd == "R" && argc != 3) {
-            return false;
-        }
+int SSDManager::convertIndexInt() {
+    return stoi(parsed_input[2]);
+}
 
-        return true;
-    }
-
-    bool isValidWriteInput(int argc) {
-        std::string& cmd = parsed_input[1];
-
-        if (cmd == "W") {
-            if (argc != 4) {
-                return false;
-            }
-
-            std::string& value = parsed_input[3];
-            if (value.length() != 10) {
-                return false;
-            }
-            if (value.substr(0, 2) != "0x") {
-                return false;
-            }
-            for (char& c : value.substr(2, 8)) {
-                if (c < '0' || (c > '9' && c < 'A') || c > 'F') {
-                    return false;
-                }
-            }
-        }
-
-        return true;
-    }
-
-    int convertIndexInt() {
-        return stoi(parsed_input[2]);
-    }
-};

--- a/SSDManager/SSDManager.cpp
+++ b/SSDManager/SSDManager.cpp
@@ -21,7 +21,7 @@ SSDManager::SSDManager(int argc, char** argv) {
 //}
 
 bool SSDManager::isValidInput() {
-    int argc = (int)parsed_input.size();
+    int argc = static_cast<int>(parsed_input.size());
 
     if (isValidCommand(argc) == false) {
         return false;

--- a/SSDManager/SSDManager.cpp
+++ b/SSDManager/SSDManager.cpp
@@ -68,8 +68,17 @@ bool SSDManager::isValidCommand(int argc) {
         return false;
     }
 
-    std::string cmd = parsed_input[1];
-    if (cmd != "W" && cmd != "R") {
+    std::string& cmd = parsed_input[1];
+
+    if (cmd.length() > 1) {
+        return false;
+    }
+    if (std::isalpha(cmd[0]) == false) {
+        return false;
+    }
+
+    char cmdCode = std::toupper(cmd[0]);
+    if (cmdCode != 'W' && cmdCode != 'R') {
         return false;
     }
 
@@ -98,8 +107,9 @@ bool SSDManager::isValidIndex(int argc) {
 
 bool SSDManager::isValidReadInput(int argc) {
     std::string& cmd = parsed_input[1];
+    char cmdCode = std::toupper(cmd[0]);
 
-    if (cmd == "R" && argc != 3) {
+    if (cmdCode == 'R' && argc != 3) {
         return false;
     }
 
@@ -108,8 +118,9 @@ bool SSDManager::isValidReadInput(int argc) {
 
 bool SSDManager::isValidWriteInput(int argc) {
     std::string& cmd = parsed_input[1];
+    char cmdCode = std::toupper(cmd[0]);
 
-    if (cmd == "W") {
+    if (cmdCode == 'W') {
         if (argc != 4) {
             return false;
         }
@@ -118,7 +129,10 @@ bool SSDManager::isValidWriteInput(int argc) {
         if (value.length() != 10) {
             return false;
         }
-        if (value.substr(0, 2) != "0x") {
+        if (value.substr(0, 1) != "0") {
+            return false;
+        }
+        if (std::toupper(value.substr(1, 1)[0]) != 'X') {
             return false;
         }
         for (char& c : value.substr(2, 8)) {

--- a/SSDManager/SSDManager.h
+++ b/SSDManager/SSDManager.h
@@ -8,7 +8,7 @@
 //#include "SSDReader.h"
 
 class SSDManager {
-public:
+ public:
     SSDManager(int argc, char** argv);
     //~SSDManager();
 
@@ -16,7 +16,7 @@ public:
     //bool executeCommand();
     std::vector<std::string> getParsedCommand();
 
-private:
+ private:
     std::vector<std::string> parsed_input;
 
     //FileManager* file_manager;

--- a/SSDManager/SSDManager.h
+++ b/SSDManager/SSDManager.h
@@ -1,0 +1,35 @@
+/* Copyright 2024 Code Love you */
+
+#pragma once
+#include <string>
+#include <vector>
+//#include "FileManager.h"
+//#include "SSDWriter.h"
+//#include "SSDReader.h"
+
+class SSDManager {
+public:
+    SSDManager(int argc, char** argv);
+    //~SSDManager();
+
+    bool isValidInput();
+    //bool executeCommand();
+    std::vector<std::string> getParsedCommand();
+
+private:
+    std::vector<std::string> parsed_input;
+
+    //FileManager* file_manager;
+    //SSDWriter* ssd_writer;
+    //SSDReader* ssd_reader;
+
+    const std::string NAND_FILE = "nand.txt";
+    const std::string RESULT_FILE = "result.txt";
+
+    bool isValidCommand(int argc);
+    bool isValidIndex(int argc);
+    bool isValidReadInput(int argc);
+    bool isValidWriteInput(int argc);
+
+    int convertIndexInt();
+};

--- a/SSDManager/SSDManager.vcxproj
+++ b/SSDManager/SSDManager.vcxproj
@@ -131,6 +131,9 @@
     <ClCompile Include="main.cpp" />
     <ClCompile Include="SSDManager.cpp" />
   </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="SSDManager.h" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/SSDManager/SSDManager.vcxproj.filters
+++ b/SSDManager/SSDManager.vcxproj.filters
@@ -25,4 +25,9 @@
       <Filter>소스 파일</Filter>
     </ClCompile>
   </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="SSDManager.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+  </ItemGroup>
 </Project>

--- a/SSDManager/StorageManager.cpp
+++ b/SSDManager/StorageManager.cpp
@@ -1,0 +1,8 @@
+#include <string>
+
+class StorageManager {
+public:
+	virtual void splitBySpace(std::string cmd) = 0;
+	virtual bool isValidCommand() = 0;
+	//virtual std::string intToHexString(unsigned int value) = 0;
+};

--- a/SSDManager/main.cpp
+++ b/SSDManager/main.cpp
@@ -1,9 +1,6 @@
 /* Copyright 2024 Code Love you */
 
-#include <iostream>
-#include <string>
-#include <vector>
-#include "SSDManager.cpp"
+#include "SSDManager.h"
 
 int main(int argc, char** argv) {
     SSDManager ssd(argc, argv);

--- a/SSDManager/main.cpp
+++ b/SSDManager/main.cpp
@@ -1,4 +1,14 @@
-int main()
-{
-	return 0;
+/* Copyright 2024 Code Love you */
+
+#include <iostream>
+#include <string>
+#include <vector>
+#include "SSDManager.cpp"
+
+int main(int argc, char** argv) {
+    SSDManager ssd(argc, argv);
+
+    //bool successFlag = ssd.executeCommand();
+
+    return 0;
 }

--- a/SSDManager/main.cpp
+++ b/SSDManager/main.cpp
@@ -6,6 +6,9 @@ int main(int argc, char** argv) {
     SSDManager ssd(argc, argv);
 
     //bool successFlag = ssd.executeCommand();
+    //if (successFlag == false) {
+    //    return -1;
+    //}
 
     return 0;
 }

--- a/SSDManagerTest/SSDManagerTest.cpp
+++ b/SSDManagerTest/SSDManagerTest.cpp
@@ -19,10 +19,20 @@ TEST(SSDManagerTest, constructorTest) {
     EXPECT_EQ(ssd.getParsedCommand(), expected);
 }
 
-TEST(SSDManagerTest, validOkayTest) {
+TEST(SSDManagerTest, validOkayTest1) {
     // Arrange
     int argc = 4;
     char* argv[] = { "ssd", "W", "2", "0x1298CDEF" };
+    SSDManager ssd(argc, argv);
+
+    // Act, Assert
+    EXPECT_EQ(ssd.isValidInput(), true);
+}
+
+TEST(SSDManagerTest, validOkayTest2) {
+    // Arrange
+    int argc = 4;
+    char* argv[] = { "ssd", "W", "2", "0X1298cDeF" };
     SSDManager ssd(argc, argv);
 
     // Act, Assert
@@ -42,7 +52,7 @@ TEST(SSDManagerTest, validFailTest1) {
 TEST(SSDManagerTest, validFailTest2) {
     // Arrange
     int argc = 4;
-    char* argv[] = { "ssd", "Write", "2", "0x1298CDEF" };
+    char* argv[] = { "ssd", "Write", "2", "0X1298cDeF" };
     SSDManager ssd(argc, argv);
 
     // Act, Assert

--- a/SSDManagerTest/SSDManagerTest.cpp
+++ b/SSDManagerTest/SSDManagerTest.cpp
@@ -99,7 +99,7 @@ TEST(SSDManagerTest, validFailTest7) {
     EXPECT_EQ(ssd.isValidInput(), false);
 }
 
-TEST(SSDManagerTest, validFailTes8) {
+TEST(SSDManagerTest, validFailTest8) {
     // Arrange
     int argc = 4;
     char* argv[] = { "ssd", "W", "2", "0xABCDEFGH" };
@@ -109,7 +109,7 @@ TEST(SSDManagerTest, validFailTes8) {
     EXPECT_EQ(ssd.isValidInput(), false);
 }
 
-TEST(SSDManagerTest, validFailTes9) {
+TEST(SSDManagerTest, validFailTest9) {
     // Arrange
     int argc = 4;
     char* argv[] = { "ssd", "R", "2", "0xABCDEFGH" };


### PR DESCRIPTION
## 구현 설명
* main.cpp 최초 업데이트 (argc, argv를 SSDManager 인스턴스에 전달)
* SSDManager.h 로 헤더파일 생성 (기존에는 cpp 파일로 통합되어 있었음)
* FileManager, SSDWriter, SSDReader를 처리하는 부분을 협의한 대로 구현하여 주석으로 반영
* TestShell.cpp에서 참고하여 isdigit() 으로 string 형태의 index를 stoi() 할 때 Exception이 발생하지 않도록 회피
* TestShell.cpp에서 참고하여 isxdigit() 으로 string 형태의 value가 16진수 형태인지 확인
* 대소문자 구분 없이 실행되도록 수정 (W/R/w/r, 0X1298CdEf 가능) -- 중복 코드가 생겨 리팩토링 예정

## exe 파일 실행 결과
에러 없이 정상 실행됨
```bash
PS C:\Users\user\source\repos\SSDTestShell\SSDTestShell\x64\Debug> ./SSDManager.exe W 2 0x1298CDEF
PS C:\Users\user\source\repos\SSDTestShell\SSDTestShell\x64\Debug>
```

## Test 결과
```bash
[==========] Running 18 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 6 tests from FileManagerTest
[ RUN      ] FileManagerTest.file_manager_test_init
[       OK ] FileManagerTest.file_manager_test_init (0 ms)
[ RUN      ] FileManagerTest.file_manager_test_open
[       OK ] FileManagerTest.file_manager_test_open (0 ms)
[ RUN      ] FileManagerTest.file_manager_test_close
[       OK ] FileManagerTest.file_manager_test_close (0 ms)
[ RUN      ] FileManagerTest.file_manager_test_read
[       OK ] FileManagerTest.file_manager_test_read (0 ms)
[ RUN      ] FileManagerTest.file_manager_test_write
[       OK ] FileManagerTest.file_manager_test_write (0 ms)
[ RUN      ] FileManagerTest.file_manager_test_write_during_read
[       OK ] FileManagerTest.file_manager_test_write_during_read (0 ms)
[----------] 6 tests from FileManagerTest (2 ms total)

[----------] 12 tests from SSDManagerTest
[ RUN      ] SSDManagerTest.constructorTest
[       OK ] SSDManagerTest.constructorTest (0 ms)
[ RUN      ] SSDManagerTest.validOkayTest1
[       OK ] SSDManagerTest.validOkayTest1 (0 ms)
[ RUN      ] SSDManagerTest.validOkayTest2
[       OK ] SSDManagerTest.validOkayTest2 (0 ms)
[ RUN      ] SSDManagerTest.validFailTest1
[       OK ] SSDManagerTest.validFailTest1 (0 ms)
[ RUN      ] SSDManagerTest.validFailTest2
[       OK ] SSDManagerTest.validFailTest2 (0 ms)
[ RUN      ] SSDManagerTest.validFailTest3
[       OK ] SSDManagerTest.validFailTest3 (0 ms)
[ RUN      ] SSDManagerTest.validFailTest4
[       OK ] SSDManagerTest.validFailTest4 (0 ms)
[ RUN      ] SSDManagerTest.validFailTest5
[       OK ] SSDManagerTest.validFailTest5 (0 ms)
[ RUN      ] SSDManagerTest.validFailTest6
[       OK ] SSDManagerTest.validFailTest6 (0 ms)
[ RUN      ] SSDManagerTest.validFailTest7
[       OK ] SSDManagerTest.validFailTest7 (0 ms)
[ RUN      ] SSDManagerTest.validFailTest8
[       OK ] SSDManagerTest.validFailTest8 (0 ms)
[ RUN      ] SSDManagerTest.validFailTest9
[       OK ] SSDManagerTest.validFailTest9 (0 ms)
[----------] 12 tests from SSDManagerTest (3 ms total)
[----------] Global test environment tear-down
[==========] 18 tests from 2 test suites ran. (7 ms total)
[  PASSED  ] 18 tests.
```