### PR TITLE
Feature/file manager

### DIFF
--- a/SSDManager/FileManager.cpp
+++ b/SSDManager/FileManager.cpp
@@ -9,13 +9,12 @@
 FileManager::FileManager() {
 }
 
-std::string FileManager::read(std::string name)
-{
+std::string FileManager::read(std::string name) {
     std::fstream resultFile(name, std::ios::in | std::ios::out);
     std::string ret;
     if (resultFile.is_open())
     {
-        /* read nand and store to the buffer */
+        /* read result and store to the buffer */
         std::stringstream buffer;
         buffer << resultFile.rdbuf();
         ret = buffer.str();

--- a/SSDManager/FileManager.cpp
+++ b/SSDManager/FileManager.cpp
@@ -9,6 +9,24 @@
 FileManager::FileManager() {
 }
 
+std::string FileManager::read(std::string name)
+{
+    std::fstream resultFile(name, std::ios::in | std::ios::out);
+    std::string ret;
+    if (resultFile.is_open())
+    {
+        /* read nand and store to the buffer */
+        std::stringstream buffer;
+        buffer << resultFile.rdbuf();
+        ret = buffer.str();
+    }
+    else {
+        throw std::invalid_argument("File is not opened");
+    }
+    resultFile.close();
+    return ret;
+}
+
 std::string FileManager::read(std::string name, int index) {
     std::fstream nandFile(name, std::ios::in | std::ios::out);
     std::string ret;

--- a/SSDManager/FileManager.h
+++ b/SSDManager/FileManager.h
@@ -9,6 +9,7 @@ class FileManager : public FileManagerInterface {
 public:
     FileManager();
     std::string read(std::string name, int index);
+    std::string read(std::string name);
     bool write(std::string name, int index, std::string value);
     bool write(std::string name, std::string value);
 private:

--- a/SSDManagerTest/FileManagerTest.cpp
+++ b/SSDManagerTest/FileManagerTest.cpp
@@ -80,3 +80,13 @@ TEST_F(FileManagerTestFixture, file_manager_test_write_during_read) {
 
     EXPECT_EQ(resultTextBuf, resultTextRef);
 }
+
+TEST_F(FileManagerTestFixture, file_manager_test_read_result)
+{
+    testWrite(TEST_NAND, TEST_NAND_MOD);
+    string resultTextRef = fm.read(TEST_NAND, 5);
+    fm.write(TEST_RESULT, resultTextRef);
+    string resultTextBuf = fm.read(TEST_RESULT);
+
+    EXPECT_EQ(resultTextBuf, resultTextRef);
+}

--- a/SSDManagerTest/FileManagerTest.cpp
+++ b/SSDManagerTest/FileManagerTest.cpp
@@ -81,8 +81,7 @@ TEST_F(FileManagerTestFixture, file_manager_test_write_during_read) {
     EXPECT_EQ(resultTextBuf, resultTextRef);
 }
 
-TEST_F(FileManagerTestFixture, file_manager_test_read_result)
-{
+TEST_F(FileManagerTestFixture, file_manager_test_read_result) {
     testWrite(TEST_NAND, TEST_NAND_MOD);
     string resultTextRef = fm.read(TEST_NAND, 5);
     fm.write(TEST_RESULT, resultTextRef);


### PR DESCRIPTION
## Background

TestAppShell needs a method for reading result.txt so it is implemented

## Test Result

Test result is as below:
```
Running main() from C:\Users\User\source\repos\SSDTestShell\packages\gmock.1.11.0\lib\native\src\gtest\src\gtest_main.cc
[==========] Running 24 tests from 4 test suites.
[----------] Global test environment set-up.
[----------] 5 tests from FileManagerTestFixture
[ RUN      ] FileManagerTestFixture.file_manager_test_read
[       OK ] FileManagerTestFixture.file_manager_test_read (151 ms)
[ RUN      ] FileManagerTestFixture.file_manager_test_write_different_index
[       OK ] FileManagerTestFixture.file_manager_test_write_different_index (94 ms)
[ RUN      ] FileManagerTestFixture.file_manager_test_write_same_index
[       OK ] FileManagerTestFixture.file_manager_test_write_same_index (183 ms)
[ RUN      ] FileManagerTestFixture.file_manager_test_write_during_read
[       OK ] FileManagerTestFixture.file_manager_test_write_during_read (133 ms)
--> newly added 
[ RUN      ] FileManagerTestFixture.file_manager_test_read_result
[       OK ] FileManagerTestFixture.file_manager_test_read_result (106 ms)

[----------] 5 tests from FileManagerTestFixture (672 ms total)
```

