### PR TITLE
[feat] add erase in SSDManager (validate, execute)

### DIFF
--- a/SSDManager/SSDManager.h
+++ b/SSDManager/SSDManager.h
@@ -6,9 +6,10 @@
 #include "FileManager.h"
 #include "SSDWriter.h"
 #include "SSDReader.h"
+#include "SSDEraser.h"
 
 class SSDManager {
- public:
+public:
     SSDManager(int argc, char** argv);
     ~SSDManager();
 
@@ -19,24 +20,23 @@ class SSDManager {
     const std::string NAND_FILE = "../../resources/nand.txt";
     const std::string RESULT_FILE = "../../resources/result.txt";
 
- private:
+private:
     std::vector<std::string> parsed_input;
     int parsed_input_arg_cnt;
 
-    const char INIT_CMDCODE = 'X';
-    const int INIT_INDEX = -1;
-    const std::string INIT_VALUE = "";
-
-    char cmd{ INIT_CMDCODE };
-    int index{ INIT_INDEX };
-    std::string value{ INIT_VALUE };
+    char cmd{ 0 };
+    int index{ -1 };
+    std::string write_value{ "" };
+    int erase_size{ -1 };
 
     FileManager* file_manager;
     SSDWriter* ssd_writer;
     SSDReader* ssd_reader;
+    SSDEraser* ssd_eraser;
 
     bool isValidCommand();
     bool isValidIndex();
     bool isValidArgCnt();
     bool isValidWriteInput();
+    bool isValidEraseInput();
 };


### PR DESCRIPTION
## 구현 내용
* erase 요청 인풋 validate
* valid한 인풋이면 SSDEraser에게 erase() 를 요청

## 유의 사항
* erase 요청 size가 10이 넘으면, 10만큼만 삭제
* erase를 요청한 index부터 size만큼 삭제하고자 할 때, 99를 넘어가면 99까지만 삭제

## 테스트 결과 (SSDManager.exe 실행)
![image](https://github.com/Kanaish/SSDTestShell/assets/26664967/6dd41934-318d-45b7-9738-8cbc48106b4d)
![image](https://github.com/Kanaish/SSDTestShell/assets/26664967/9604f9b3-5b45-4e8f-9487-670cd5289258)
