### PR TITLE
[hotfix] Change token generator for searching error

### DIFF
--- a/SSDManager/FileManager.cpp
+++ b/SSDManager/FileManager.cpp
@@ -106,10 +106,10 @@ bool FileManager::write(std::string name, std::string value) {
 
 std::string FileManager::generateToken(int index)
 {
-    return std::string("LBA" + std::to_string(index));
+    return std::string("LBA" + std::to_string(index) + " ");
 }
 
 std::string FileManager::generateMemoryBlock(std::string token, std::string value)
 {
-    return token + " " + value + " ";
+    return token + value + " ";
 }


### PR DESCRIPTION
Current system, after writing LBA 1x, LBA1x
Read operation with R 1 doesn't return 0x00000000

So, corret token generator function

## Test Result

```
[----------] Global test environment tear-down
[==========] 28 tests from 6 test suites ran. (713 ms total)
[  PASSED  ] 28 tests.
```