### PR TITLE
[fix] delete LOG() from FileManager

### DIFF
--- a/SSDManager/FileManager.cpp
+++ b/SSDManager/FileManager.cpp
@@ -10,7 +10,6 @@ FileManager::FileManager() {
 }
 
 std::string FileManager::read(std::string name) {
-    LOG("Read Result");
     std::fstream resultFile(name, std::ios::in | std::ios::out);
     std::string ret;
 
@@ -29,7 +28,6 @@ std::string FileManager::read(std::string name) {
 }
 
 std::string FileManager::read(std::string name, int index) {
-    LOG("Read Nand");
     std::fstream nandFile(name, std::ios::in | std::ios::out);
     std::string ret;
     if (nandFile.is_open())
@@ -59,7 +57,6 @@ std::string FileManager::read(std::string name, int index) {
 }
 
 bool FileManager::write(std::string name, int index, std::string value) {
-    LOG("Write Nand");
     std::fstream nandFile(name, std::ios::in | std::ios::out);
     if (nandFile.is_open()) {
         nandFile.seekp(0, std::ios::beg);
@@ -90,7 +87,6 @@ bool FileManager::write(std::string name, int index, std::string value) {
 }
 
 bool FileManager::write(std::string name, std::string value) {
-    LOG("Write Result");
     std::fstream resultFile(name, std::ios::in | std::ios::out);
     if (resultFile.is_open()) {
         resultFile.seekp(0, std::ios::beg);


### PR DESCRIPTION
## 변경 내용
* fullread, fullwrite 시 로깅이 많아 오류가 발생하여 FileManager의 로깅 삭제