### PR TITLE
[feat] erase in buffer can be applied to fast read (not have to flush)

### DIFF
--- a/SSDManager/CommandBuffer.cpp
+++ b/SSDManager/CommandBuffer.cpp
@@ -158,8 +158,17 @@ std::vector<BufferData> CommandBuffer::flushBuffer() {
 
 std::string CommandBuffer::findMatchedWrite(int index) {
     for (int i = data.size() - 1; i >= 0; i--) {
-        if (data[i].index == index && data[i].cmd == 'W') {
+        if (data[i].cmd == 'W' && data[i].index == index) {
             return data[i].write_value;
+        }
+    }
+    return "";
+}
+
+std::string CommandBuffer::findMatchedErase(int index) {
+    for (int i = data.size() - 1; i >= 0; i--) {
+        if (data[i].cmd == 'E' && data[i].index <= index && index <= data[i].getLastIndex()) {
+            return ERASED_VALUE;
         }
     }
     return "";

--- a/SSDManager/CommandBuffer.h
+++ b/SSDManager/CommandBuffer.h
@@ -34,6 +34,7 @@ class CommandBuffer {
     bool isFullBuffer();
     std::vector<BufferData> flushBuffer();
     std::string findMatchedWrite(int);
+    std::string findMatchedErase(int);
     bool flushBufferFile();
 
     const std::string BUFFER_FILE_NAME = "../../resources/buffer.txt";
@@ -52,5 +53,6 @@ class CommandBuffer {
     const char DELIMETER_STRING = ',';
     const char SPACE_STRING = ' ';
     const int BUFFER_MAX = 10;
+    const std::string ERASED_VALUE = "0x00000000";
     const std::string CLASS_NAME = "CommandBuffer";
 };

--- a/SSDManager/SSDManager.cpp
+++ b/SSDManager/SSDManager.cpp
@@ -58,6 +58,9 @@ bool SSDManager::executeCommand() {
     if (cmd == 'R') {
         std::string buffer_ret = command_buffer->findMatchedWrite(index);
         if (buffer_ret == "") {
+            buffer_ret = command_buffer->findMatchedErase(index);
+        }
+        if (buffer_ret == "") {
             return ssd_reader->read(NAND_FILE, RESULT_FILE, index);
         }
         try {


### PR DESCRIPTION
## 구현 내용
* 기존에는 nand.txt에 LBA1 0x12341234 가 쓰여있고 erase 1 5 명령을 날리면 buffer.txt에 E 1 5, 명령이 저장되고, read 1 명령을 날리면 buffer.txt에 W 1 명령이 없으므로 nand.txt에서 1번지를 읽어 0x12341234를 리턴함
* buffer.txt를 먼저 검사할 때, 기존에 W만 고려했던 것을 E도 고려하여 R을 요청한 번지가 E 범위에 들어있으면 0x00000000을 리턴하게 변경함
* buffer.txt에 커맨드를 저장할 때 W와 겹치는 E가 들어오면 앞에 있는 W를 삭제하기 때문에, 매치되는 W가 있는지 확인하고 없으면 매치되는 E가 있는지 확인하는 것으로 구현함

## 테스트 내용
* SSDManager.exe, TestShell.exe fullwrite, fullread, testapp1, testapp2 확인 완료