### PR TITLE
[style] Adapting cpplint

### DIFF
--- a/SSDManager/CommandBuffer.cpp
+++ b/SSDManager/CommandBuffer.cpp
@@ -1,4 +1,5 @@
 /* Copyright 2024 Code Love you */
+
 #include <iostream>
 #include <fstream>
 #include <sstream>
@@ -19,20 +20,23 @@ bool CommandBuffer::updateBuffer(BufferData new_data) {
 
     if (new_data.cmd == 'W') {
         bool optimize_applied = false;
-
-        if (optimize_applied = ignoreDupWrite(new_data, new_data.index, new_data.index)) {  // Opt1
+        // Opt1
+        if (optimize_applied = ignoreDupWrite(new_data, new_data.index,
+                                                        new_data.index)) {
             LOG("Ignore Duplicated Write Optimization (#1) Applied.");
         }
 
         optimize_applied = false;
-        if (optimize_applied = narrowEraseRangeSeveralTimes(new_data)) {  // Opt 4
+        // Opt 4
+        if (optimize_applied = narrowEraseRangeSeveralTimes(new_data)) {
             LOG("Narrow Erase Range Optimization (#4) Applied.");
         }
     }
     if (new_data.cmd == 'E') {
         bool optimize_applied = false;
-
-        if (optimize_applied = ignoreDupWrite(new_data, new_data.index, new_data.getLastIndex())) {  // Opt2
+        // Opt2
+        if (optimize_applied = ignoreDupWrite(new_data, new_data.index,
+                                              new_data.getLastIndex())) {
             LOG("Ignore Duplicated Write Optimization (#2) Applied.");
         }
 
@@ -167,7 +171,8 @@ std::string CommandBuffer::findMatchedWrite(int index) {
 
 std::string CommandBuffer::findMatchedErase(int index) {
     for (int i = data.size() - 1; i >= 0; i--) {
-        if (data[i].cmd == 'E' && data[i].index <= index && index <= data[i].getLastIndex()) {
+        if (data[i].cmd == 'E' && data[i].index <= index &&
+                         index <= data[i].getLastIndex()) {
             return ERASED_VALUE;
         }
     }

--- a/SSDManager/FileManager.cpp
+++ b/SSDManager/FileManager.cpp
@@ -13,14 +13,12 @@ std::string FileManager::read(std::string name) {
     std::fstream resultFile(name, std::ios::in | std::ios::out);
     std::string ret;
 
-    if (resultFile.is_open())
-    {
+    if (resultFile.is_open()) {
         /* read result and store to the buffer */
         std::stringstream buffer;
         buffer << resultFile.rdbuf();
         ret = buffer.str();
-    }
-    else {
+    } else {
         throw std::invalid_argument("File is not opened");
     }
     resultFile.close();
@@ -30,8 +28,7 @@ std::string FileManager::read(std::string name) {
 std::string FileManager::read(std::string name, int index) {
     std::fstream nandFile(name, std::ios::in | std::ios::out);
     std::string ret;
-    if (nandFile.is_open())
-    {
+    if (nandFile.is_open()) {
         /* read nand and store to the buffer */
         std::stringstream buffer;
         buffer << nandFile.rdbuf();
@@ -43,13 +40,11 @@ std::string FileManager::read(std::string name, int index) {
             /* If token is found, read LBA */
             size_t posValue = buffer.str().find(" ", pos);
             ret = buffer.str().substr(posValue + 1, VALUE_LEN);
-        }
-        else {
+        } else {
             /* If not, return empty value */
             ret = EMPTY;
         }
-    }
-    else {
+    } else {
         throw std::invalid_argument("File is not opened");
     }
     nandFile.close();
@@ -71,14 +66,12 @@ bool FileManager::write(std::string name, int index, std::string value) {
             /* If token is found, replace LBA with given value */
             nandFile.seekp(pos, std::ios::beg);
             nandFile << generateMemoryBlock(generateToken(index), value);
-        }
-        else {
+        } else {
             /* If not, replace LBA with given value */
             nandFile.seekp(0, std::ios::end);
             nandFile << generateMemoryBlock(generateToken(index), value);
         }
-    }
-    else {
+    } else {
         throw std::invalid_argument("File is not opened");
         return false;
     }
@@ -91,8 +84,7 @@ bool FileManager::write(std::string name, std::string value) {
     if (resultFile.is_open()) {
         resultFile.seekp(0, std::ios::beg);
         resultFile << value;
-    }
-    else {
+    } else {
         throw std::invalid_argument("File is not opened");
         return false;
     }
@@ -100,12 +92,11 @@ bool FileManager::write(std::string name, std::string value) {
     return true;
 }
 
-std::string FileManager::generateToken(int index)
-{
+std::string FileManager::generateToken(int index) {
     return std::string("LBA" + std::to_string(index) + " ");
 }
 
-std::string FileManager::generateMemoryBlock(std::string token, std::string value)
-{
+std::string FileManager::generateMemoryBlock(std::string token,
+                                             std::string value) {
     return token + value + " ";
 }

--- a/SSDManager/FileManager.h
+++ b/SSDManager/FileManager.h
@@ -6,13 +6,13 @@
 #include "FileManagerInterface.h"
 #include "LogManager.h"
 class FileManager : public FileManagerInterface {
-public:
+ public:
     FileManager();
     std::string read(std::string name, int index);
     std::string read(std::string name);
     bool write(std::string name, int index, std::string value);
     bool write(std::string name, std::string value);
-private:
+ private:
     std::string generateToken(int index);
     std::string generateMemoryBlock(std::string token, std::string value);
     const std::string EMPTY = "0x00000000";

--- a/SSDManager/FileManager.h
+++ b/SSDManager/FileManager.h
@@ -1,4 +1,5 @@
 /* Copyright 2024 Code Love you */
+
 #pragma once
 #include <iostream>
 #include <fstream>

--- a/SSDManager/FileManagerInterface.h
+++ b/SSDManager/FileManagerInterface.h
@@ -3,7 +3,7 @@
 #include <string>
 
 class FileManagerInterface {
-public:
+ public:
     virtual std::string read(std::string name) = 0;
     virtual std::string read(std::string name, int index) = 0;
     virtual bool write(std::string name, int index, std::string value) = 0;;

--- a/SSDManager/FileManagerInterface.h
+++ b/SSDManager/FileManagerInterface.h
@@ -1,4 +1,5 @@
 /* Copyright 2024 Code Love you */
+
 #pragma once
 #include <string>
 

--- a/SSDManager/LogManager.cpp
+++ b/SSDManager/LogManager.cpp
@@ -1,15 +1,15 @@
 /* Copyright 2024 Code Love you */
+#include "LogManager.h"
+#include <windows.h>
+#include <ctime>
 #include <iostream>
 #include <fstream>
 #include <sstream>
 #include <stdexcept>
-#include <ctime>
-#include <iostream>
-#include <windows.h>
 #include <string>
 #include <locale>
 #include <codecvt>
-#include "LogManager.h"
+
 
 LogManager& LogManager::getLogManagerInstance(void) {
     static LogManager instance;
@@ -17,14 +17,16 @@ LogManager& LogManager::getLogManagerInstance(void) {
 }
 
 LogManager::LogManager() {
-
 }
 
-void LogManager::logWrite(std::string className, std::string mFunctionName, std::string msg) {
+void LogManager::logWrite(std::string className,
+                        std::string mFunctionName,
+                        std::string msg) {
     std::string logTitle(50, ' ');
     std::string buf = className + "::" + mFunctionName;
     logTitle.replace(0, buf.length(), buf);
-    std::string logMessage = logGetCurrentTimeForLogging() + logTitle + msg + "\n";
+    std::string logMessage = logGetCurrentTimeForLogging() +
+                                        logTitle + msg + "\n";
 
     std::ofstream logFile(LOG_DIR + CURRENT_LOG, std::ios::out | std::ios::app);
     if (logFile.is_open()) {
@@ -33,33 +35,36 @@ void LogManager::logWrite(std::string className, std::string mFunctionName, std:
         size_t pos = logFile.tellp();
         if (pos > LIMIT_LOG_SIZE) {
             logFile.close();
-            std::string logNewFileName = LOG_DIR +"Until_" + logGetCurrentTimeForFileName() + ".log";
+            std::string logNewFileName = LOG_DIR +"Until_" +
+                                       logGetCurrentTimeForFileName() + ".log";
 
-            if (std::rename((LOG_DIR + CURRENT_LOG).c_str(), logNewFileName.c_str()) != 0) {
+            if (std::rename((LOG_DIR + CURRENT_LOG).c_str(),
+                                     logNewFileName.c_str()) != 0) {
                 std::cerr << "Error renaming file" << std::endl;
                 return;
             }
-            if (getOldLogFileNum() == 2)
-            {
+            if (getOldLogFileNum() == 2) {
                 std::string oldestFileName = LOG_DIR + getOldestLogFileName();
                 std::string changedOldestFileName = oldestFileName;
 
                 size_t pos = oldestFileName.find(".log");
                 changedOldestFileName.replace(pos, 4, ".zip");
-                if (std::rename(oldestFileName.c_str(), changedOldestFileName.c_str()) != 0) {
+                if (std::rename(oldestFileName.c_str(),
+                                changedOldestFileName.c_str()) != 0) {
                     std::cerr << "Error renaming file" << std::endl;
                     return;
                 }
             }
         }
-    }
-    else {
-
+    } else {
+        throw std::invalid_argument("File is not opened");
     }
     logFile.close();
 }
-void LogManager::logPrint(std::string className, std::string mFunctionName, std::string msg) {
-    std::string logTitle(50, ' ');
+void LogManager::logPrint(std::string className,
+                          std::string mFunctionName,
+                          std::string msg) {
+    std::string logTitle(LOG_TITLE_LIMIT, ' ');
     std::string buf = className + "::" + mFunctionName;
     logTitle.replace(0, buf.length(), buf);
     std::string logMessage = logGetCurrentTimeForLogging() + logTitle + msg;
@@ -103,8 +108,7 @@ int LogManager::getOldLogFileNum(void) {
         return count;
 }
 
-std::string LogManager::getOldestLogFileName(void)
-{
+std::string LogManager::getOldestLogFileName(void) {
     WIN32_FIND_DATA data;
     HANDLE hFind;
     FILETIME oldestTime;
@@ -130,16 +134,18 @@ std::string LogManager::getOldestLogFileName(void)
         /* Convert file time into system time  */
         FileTimeToSystemTime(&oldestTime, &stUTC);
         SystemTimeToTzSpecificLocalTime(NULL, &stUTC, &stLocal);
-    }
-    else {
+    } else {
         std::cout << "No .log files found.\n";
     }
     return oldestFile;
 }
 
 std::string LogManager::WideStringToString(const std::wstring& wstr) {
-    int size_needed = WideCharToMultiByte(CP_UTF8, 0, wstr.c_str(), (int)wstr.size(), NULL, 0, NULL, NULL);
+    int size_needed = WideCharToMultiByte(CP_UTF8, 0, wstr.c_str(),
+                           static_cast<int>(wstr.size()), NULL, 0, NULL, NULL);
     std::string strTo(size_needed, 0);
-    WideCharToMultiByte(CP_UTF8, 0, wstr.c_str(), (int)wstr.size(), &strTo[0], size_needed, NULL, NULL);
+    WideCharToMultiByte(CP_UTF8, 0, wstr.c_str(),
+                        static_cast<int>(wstr.size()),
+                        &strTo[0], size_needed, NULL, NULL);
     return strTo;
 }

--- a/SSDManager/LogManager.cpp
+++ b/SSDManager/LogManager.cpp
@@ -1,5 +1,5 @@
 /* Copyright 2024 Code Love you */
-#include "LogManager.h"
+
 #include <windows.h>
 #include <ctime>
 #include <iostream>
@@ -9,7 +9,7 @@
 #include <string>
 #include <locale>
 #include <codecvt>
-
+#include "LogManager.h"
 
 LogManager& LogManager::getLogManagerInstance(void) {
     static LogManager instance;

--- a/SSDManager/LogManager.h
+++ b/SSDManager/LogManager.h
@@ -1,4 +1,5 @@
 /* Copyright 2024 Code Love you */
+
 #pragma once
 #include <windows.h>
 #include <iostream>

--- a/SSDManager/LogManager.h
+++ b/SSDManager/LogManager.h
@@ -1,31 +1,39 @@
 /* Copyright 2024 Code Love you */
 #pragma once
+#include <windows.h>
 #include <iostream>
 #include <fstream>
 #include <string>
-#include <windows.h>
 
-
-#define LOG_STORE(msg) do {LogManager::getLogManagerInstance().logPrint(CLASS_NAME, __func__, msg);} while(0)
-#define LOG_PRINT(msg) do {LogManager::getLogManagerInstance().logWrite(CLASS_NAME, __func__, msg);} while(0)
-#define LOG(msg) do {LOG_PRINT(msg); LOG_STORE(msg);} while(0)
+#define LOG_STORE(msg) do {LogManager::getLogManagerInstance().logPrint\
+                                     (CLASS_NAME, __func__, msg);}while(0)
+#define LOG_PRINT(msg) do {LogManager::getLogManagerInstance().logWrite\
+                                     (CLASS_NAME, __func__, msg);}while(0)
+#define LOG(msg) do {LOG_PRINT(msg); LOG_STORE(msg);}while(0)
 
 class LogManager {
-public:
+ public:
     static LogManager& getLogManagerInstance(void);
-    void logWrite(std::string className, std::string mFunctionName, std::string msg);
-    void logPrint(std::string className, std::string mFunctionName, std::string msg);
-private:
+    void logWrite(std::string className, std::string mFunctionName,
+                                                    std::string msg);
+    void logPrint(std::string className, std::string mFunctionName,
+                                                    std::string msg);
+
+ private:
     LogManager();
+
     std::string logGetCurrentTimeForLogging(void);
     std::string logGetCurrentTimeForFileName(void);
     int getOldLogFileNum(void);
     std::string getOldestLogFileName(void);
     std::string WideStringToString(const std::wstring& wstr);
+
     const std::string LOG_DIR = "..\\..\\log\\";
     const std::string CURRENT_LOG = "lastest.log";
     const wchar_t* PATH = L"../../\\log\\*_*_*_*_*_*.log";;
     const int LIMIT_LOG_SIZE = 10*1000;
+    const int LOG_TITLE_LIMIT = 50;
+
     LogManager& operator=(const LogManager& other) = delete;
     LogManager(const LogManager& other) = delete;
 };

--- a/SSDManager/SSDEraser.cpp
+++ b/SSDManager/SSDEraser.cpp
@@ -1,4 +1,5 @@
 /* Copyright 2024 Code Love you */
+
 #include <iostream>
 #include <stdexcept>
 #include "SSDEraser.h"
@@ -7,7 +8,9 @@ SSDEraser::SSDEraser(FileManagerInterface* fm) :file_mgr{ fm } {}
 bool  SSDEraser::erase(const std::string& nand_file, int index, int size) {
     try {
         for (int i = 0; i < size; i++) {
-            if (file_mgr->write(nand_file, index + i, INIT_VALUE) == false)  return false ;
+            if (file_mgr->write(nand_file, index + i, INIT_VALUE) == false) {
+                return false;
+            }
         }
         return true;
     }

--- a/SSDManager/SSDEraser.h
+++ b/SSDManager/SSDEraser.h
@@ -1,13 +1,15 @@
 /* Copyright 2024 Code Love you */
+
 #pragma once
-#include<string>
+#include <string>
 #include "FileManager.h"
 #include "LogManager.h"
+
 class SSDEraser {
-public:
+ public:
     explicit SSDEraser(FileManagerInterface* file_mgr);
     bool erase(const std::string& nand_file, int index, int size);
-private:
+ private:
     FileManagerInterface* file_mgr;
     const std::string INIT_VALUE = "0x00000000";
     const std::string CLASS_NAME = "SSDErase";

--- a/SSDManager/SSDManager.cpp
+++ b/SSDManager/SSDManager.cpp
@@ -1,5 +1,7 @@
 /* Copyright 2024 Code Love you */
 
+#include <vector>
+#include <string>
 #include "SSDManager.h"
 #include "LogManager.h"
 
@@ -9,7 +11,7 @@ SSDManager::SSDManager(int argc, char** argv) {
     }
 
     parsed_input_arg_cnt = argc;
-    // TODO: Factory Pattern
+
     file_manager = new FileManager();
     ssd_writer = new SSDWriter(file_manager);
     ssd_reader = new SSDReader(file_manager);
@@ -34,7 +36,7 @@ bool SSDManager::isValidInput() {
         return false;
     }
 
-    if (isValidArgCnt() == false) { 
+    if (isValidArgCnt() == false) {
         return false;
     }
 
@@ -93,12 +95,14 @@ bool SSDManager::executeCommand() {
 
     for (BufferData& data : flushed_data) {
         if (data.cmd == 'W') {
-            if (ssd_writer->write(NAND_FILE, data.index, data.write_value) == false) {
+            if (ssd_writer->write(NAND_FILE, data.index,
+                                             data.write_value) == false) {
                 return false;
             }
         }
         if (data.cmd == 'E') {
-            if (ssd_eraser->erase(NAND_FILE, data.index, data.erase_size) == false) {
+            if (ssd_eraser->erase(NAND_FILE, data.index,
+                                             data.erase_size) == false) {
                 return false;
             }
         }

--- a/SSDManager/SSDManager.h
+++ b/SSDManager/SSDManager.h
@@ -1,6 +1,8 @@
 /* Copyright 2024 Code Love you */
 
 #pragma once
+#include <vector>
+#include <string>
 #include "FileManager.h"
 #include "LogManager.h"
 #include "SSDWriter.h"
@@ -9,7 +11,7 @@
 #include "CommandBuffer.h"
 
 class SSDManager {
-public:
+ public:
     SSDManager(int argc, char** argv);
     ~SSDManager();
 
@@ -20,7 +22,7 @@ public:
     const std::string NAND_FILE = "../../resources/nand.txt";
     const std::string RESULT_FILE = "../../resources/result.txt";
 
-private:
+ private:
     std::vector<std::string> parsed_input;
     int parsed_input_arg_cnt;
 

--- a/SSDManager/SSDReader.cpp
+++ b/SSDManager/SSDReader.cpp
@@ -1,4 +1,5 @@
 /* Copyright 2024 Code Love you */
+
 #include <iostream>
 #include "SSDReader.h"
 
@@ -22,7 +23,7 @@ std::string SSDReader::readSSDValue(const std::string& nand_file, int index) {
 }
 
 bool SSDReader::writeResultValue(const std::string& result_file,
-    std::string& result) {
+    const std::string& result) {
     try {
         return fm->write(result_file, result);
     }

--- a/SSDManager/SSDReader.h
+++ b/SSDManager/SSDReader.h
@@ -11,7 +11,8 @@ class SSDReader {
     bool read(const std::string& nand_file,
     const std::string& result_file, int index);
  private:
-    bool writeResultValue(const std::string& result_file, std::string& result);
+    bool writeResultValue(const std::string& result_file,
+                          const std::string& result);
     std::string readSSDValue(const std::string& nand_file, int index);
 
     FileManagerInterface* fm;

--- a/SSDManager/SSDWriter.cpp
+++ b/SSDManager/SSDWriter.cpp
@@ -1,4 +1,5 @@
 /* Copyright 2024 Code Love you */
+
 #include <iostream>
 #include <stdexcept>
 #include "SSDWriter.h"

--- a/SSDManager/SSDWriter.h
+++ b/SSDManager/SSDWriter.h
@@ -4,10 +4,10 @@
 #include "FileManager.h"
 
 class SSDWriter {
-public:
+ public:
     explicit SSDWriter(FileManagerInterface* file_mgr);
     bool write(std::string nand_file, int index, std::string value);
-private:
+ private:
     FileManagerInterface* file_mgr;
     const std::string CLASS_NAME = "SSDWriter";
 };

--- a/SSDManager/main.cpp
+++ b/SSDManager/main.cpp
@@ -5,7 +5,7 @@
 
 int main(int argc, char** argv) {
     SSDManager ssd(argc, argv);
-    
+
     bool success_flag = ssd.executeCommand();
     if (success_flag == false) {
         return -1;

--- a/SSDManagerTest/CommandBufferTest.cpp
+++ b/SSDManagerTest/CommandBufferTest.cpp
@@ -4,19 +4,3 @@
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 #include "../SSDManager/CommandBuffer.cpp"
-
-/*
-typedef struct BufferData {
-    char cmd;
-    int index;
-    std::string write_value;
-    int erase_size;
-};
-*/
-#if 0
-TEST(CommandBufferTest, SetCommandBufferTest) {
-    CommandBuffer buf;
-    BufferData data = { 'W', 1, "0x55555555", 0 };
-    buf.updateBuffer(data);
-}
-#endif

--- a/SSDManagerTest/FileManagerTest.cpp
+++ b/SSDManagerTest/FileManagerTest.cpp
@@ -20,24 +20,23 @@ using namespace std;
 using namespace testing;
 
 class FileManagerTestFixture : public Test {
-public:
+ public:
     FileManager fm;
     stringstream testBuf, testRef;
     string textBuf = "";
     string textRef = "";
     stringstream resultTestBuf;
     string resultTextBuf = "";
-    void testWrite(string name, int mod)
-    {
+    void testWrite(string name, int mod) {
         for (int i = 0; i < 100; i++) {
             fm.write(name, i % mod, "0x" + to_string(10000000 + i));
         }
     }
-    fstream testFile{ TEST_NAND, std::ios::in | std::ios::out | std::ios::trunc };
-    fstream refFile{ TEST_NAND_REF, std::ios::in | std::ios::out | std::ios::beg };
-    fstream testDiffFile{ TEST_NAND_DIFF, std::ios::in | std::ios::out | std::ios::trunc };
-    fstream refDiffFile{ TEST_NAND_DIFF_REF, std::ios::in | std::ios::out | std::ios::beg };
-    fstream testResultFile{ TEST_RESULT, std::ios::in | std::ios::out | std::ios::trunc };
+    fstream testFile{ TEST_NAND, ios::in | ios::out | ios::trunc };
+    fstream refFile{ TEST_NAND_REF, ios::in | ios::out | ios::beg };
+    fstream testDiffFile{ TEST_NAND_DIFF, ios::in | ios::out | ios::trunc };
+    fstream refDiffFile{ TEST_NAND_DIFF_REF, ios::in | ios::out | ios::beg };
+    fstream testResultFile{ TEST_RESULT, ios::in | ios::out | ios::trunc };
 };
 
 TEST_F(FileManagerTestFixture, file_manager_test_read) {
@@ -49,7 +48,7 @@ TEST_F(FileManagerTestFixture, file_manager_test_read) {
 
 TEST_F(FileManagerTestFixture, file_manager_test_write_different_index) {
     testWrite(TEST_NAND, TEST_NAND_MOD);
-    
+
     testBuf << testFile.rdbuf();
     testRef << refFile.rdbuf();
 

--- a/SSDManagerTest/SSDEraserTest.cpp
+++ b/SSDManagerTest/SSDEraserTest.cpp
@@ -11,16 +11,17 @@ using namespace std;
 using namespace testing;
 
 class FileManagerEraserMock :public FileManagerInterface {
-public:
+ public:
     MOCK_METHOD(string, read, (string name), (override));
     MOCK_METHOD(string, read, (string name, int index), (override));
-    MOCK_METHOD(bool, write, (string name, int index, string value), (override));
+    MOCK_METHOD(bool, write, (string name, int index,
+                                           string value), (override));
     MOCK_METHOD(bool, write, (string name, string value), (override));
 };
 
 
 class FileManagerEraserFixture :public Test {
-public:
+ public:
     FileManager m;
     SSDEraser ssd_real_eraser{ &m };
     FileManagerEraserMock fm;
@@ -29,34 +30,30 @@ public:
     const int TEST_START_INDEX = 10;
     const int TEST_ERASE_SIZE = 10;
     const string TEST_INIT_VALUE = "0x00000000";
-
 };
-//// ssd_eraser Normal behavior Test -> Erase test_nand.txt
+// ssd_eraser Normal behavior Test -> Erase test_nand.txt
 TEST_F(FileManagerEraserFixture, easer_normal_function_Test) {
-    bool result = ssd_real_eraser.erase(NAND_FILE, TEST_START_INDEX, TEST_ERASE_SIZE);
+    bool result = ssd_real_eraser.erase(NAND_FILE, TEST_START_INDEX,
+                                                   TEST_ERASE_SIZE);
     EXPECT_THAT(result, testing::Eq(true));
 }
 
-//// ssd_eraser behavior Test  Case False Return
+// ssd_eraser behavior Test  Case False Return
 TEST_F(FileManagerEraserFixture, erase_behavior_call_fm_write_functon) {
-
     EXPECT_CALL(fm, write(NAND_FILE, _, TEST_INIT_VALUE))
         .Times(TEST_ERASE_SIZE)
         .WillRepeatedly(Return(true));
 
-    EXPECT_THAT(ssd_eraser.erase(NAND_FILE, TEST_START_INDEX, TEST_ERASE_SIZE), IsTrue());
+    EXPECT_THAT(ssd_eraser.erase(NAND_FILE, TEST_START_INDEX,
+                                            TEST_ERASE_SIZE), IsTrue());
 }
-
 
 // ssd_eraser behavior EXCEPTION Case False Return
 TEST_F(FileManagerEraserFixture, Write_behavior_Exception_return_false_check) {
-
     EXPECT_CALL(fm, write(NAND_FILE, TEST_START_INDEX, TEST_INIT_VALUE))
         .Times(1)
         .WillOnce(Throw(std::exception()));
 
-    EXPECT_THAT(ssd_eraser.erase(NAND_FILE, TEST_START_INDEX, TEST_ERASE_SIZE), IsFalse());
+    EXPECT_THAT(ssd_eraser.erase(NAND_FILE, TEST_START_INDEX,
+                                            TEST_ERASE_SIZE), IsFalse());
 }
-
-
-

--- a/SSDManagerTest/SSDReaderTest.cpp
+++ b/SSDManagerTest/SSDReaderTest.cpp
@@ -6,31 +6,34 @@
 #include "../SSDManager/FileManager.h"
 #include "../SSDManager/SSDReader.cpp"
 
-static const std::string RESULT_NAME_PATH = "test_result.txt";
-static const std::string NAND_NAME_PATH = "test_nand.txt";
+using namespace std;
+using namespace testing;
+
+#define RESULT_NAME_PATH "test_result.txt";
+#define NAND_NAME_PATH   "test_nand.txt";
 
 class FileManagerReaderMock : public FileManagerInterface {
  public:
-    MOCK_METHOD(std::string, read, (std::string name), (override));
-    MOCK_METHOD(std::string, read, (std::string, int), (override));
-    MOCK_METHOD(bool, write, (std::string, int, std::string), (override));
-    MOCK_METHOD(bool, write, (std::string, std::string), (override));
+    MOCK_METHOD(string, read, (string name), (override));
+    MOCK_METHOD(string, read, (string, int), (override));
+    MOCK_METHOD(bool, write, (string, int, string), (override));
+    MOCK_METHOD(bool, write, (string, string), (override));
 };
 
-class SSDReaderFileManagerMockFixture: public testing::Test {
+class SSDReaderFileManagerMockFixture: public Test {
  public:
-    testing::NiceMock<FileManagerReaderMock> mock;
-    std::string value = "0x12345678";
-    std::string nand_file = NAND_NAME_PATH;
-    std::string result_file = RESULT_NAME_PATH;
+    NiceMock<FileManagerReaderMock> mock;
+    string value = "0x12345678";
+    string nand_file = NAND_NAME_PATH;
+    string result_file = RESULT_NAME_PATH;
 };
 
 TEST_F(SSDReaderFileManagerMockFixture, FileManagerReaderMockReadTest) {
-    std::string result;
+    string result;
     int index = 0;
 
     EXPECT_CALL(mock, read(nand_file, index))
-        .WillRepeatedly(testing::Return(std::string(value)));
+        .WillRepeatedly(Return(string(value)));
 
     result = mock.read(nand_file, index);
 
@@ -40,10 +43,10 @@ TEST_F(SSDReaderFileManagerMockFixture, FileManagerReaderMockReadTest) {
 TEST_F(SSDReaderFileManagerMockFixture, FileManagerReaderMockWriteTest) {
     bool result;
 
-    std::string result_file = RESULT_NAME_PATH;
+    string result_file = RESULT_NAME_PATH;
 
     EXPECT_CALL(mock, write(result_file, value))
-        .WillRepeatedly(testing::Return(true));
+        .WillRepeatedly(Return(true));
 
     result = mock.write(result_file, value);
 
@@ -57,15 +60,15 @@ TEST_F(SSDReaderFileManagerMockFixture, NormalReadTestWithMock) {
 
     EXPECT_CALL(mock, read(nand_file, index))
         .Times(1)
-        .WillOnce(testing::Return(std::string(value)));
+        .WillOnce(Return(string(value)));
 
     EXPECT_CALL(mock, write(result_file, value))
         .Times(1)
-        .WillOnce(testing::Return(true));
+        .WillOnce(Return(true));
 
     SSDReader reader{ &mock };
     result = reader.read(nand_file, result_file, index);
-    EXPECT_THAT(result, testing::Eq(true));
+    EXPECT_THAT(result, Eq(true));
 }
 
 TEST_F(SSDReaderFileManagerMockFixture, ExceptionReadWithMock) {
@@ -73,14 +76,14 @@ TEST_F(SSDReaderFileManagerMockFixture, ExceptionReadWithMock) {
     int index = 0;
 
     EXPECT_CALL(mock, read(nand_file, index))
-        .WillRepeatedly(testing::Throw(std::exception()));
+        .WillRepeatedly(Throw(exception()));
 
     EXPECT_CALL(mock, write(result_file, value))
-        .WillRepeatedly(testing::Return(true));
+        .WillRepeatedly(Return(true));
 
     SSDReader reader{ &mock };
     result = reader.read(nand_file, result_file, index);
-    EXPECT_THAT(result, testing::Eq(false));
+    EXPECT_THAT(result, Eq(false));
 }
 
 TEST_F(SSDReaderFileManagerMockFixture, ExceptionWriteWithMock) {
@@ -89,15 +92,15 @@ TEST_F(SSDReaderFileManagerMockFixture, ExceptionWriteWithMock) {
 
     EXPECT_CALL(mock, read(nand_file, index))
         .Times(1)
-        .WillRepeatedly(testing::Return(std::string(value)));
+        .WillRepeatedly(Return(string(value)));
 
     EXPECT_CALL(mock, write(result_file, value))
         .Times(1)
-        .WillOnce(testing::Throw(std::exception()));
+        .WillOnce(Throw(exception()));
 
     SSDReader reader{ &mock };
     result = reader.read(nand_file, result_file, index);
-    EXPECT_THAT(result, testing::Eq(false));
+    EXPECT_THAT(result, Eq(false));
 }
 
 
@@ -106,18 +109,11 @@ TEST(SSDReaderTest, NormalReadTest) {
     bool result;
 
     int index = 0;
-    std::string nand_file = NAND_NAME_PATH;
-    std::string result_file = RESULT_NAME_PATH;
+    string nand_file = NAND_NAME_PATH;
+    string result_file = RESULT_NAME_PATH;
 
     SSDReader reader{ &m };
     result = reader.read(nand_file, result_file, index);
 
-    EXPECT_THAT(result, testing::Eq(true));
+    EXPECT_THAT(result, Eq(true));
 }
-
-
-
-
-
-
-

--- a/SSDManagerTest/SSDWriterTest.cpp
+++ b/SSDManagerTest/SSDWriterTest.cpp
@@ -1,4 +1,5 @@
 /* Copyright 2024 Code Love you */
+
 #include <iostream>
 #include <fstream>
 #include <cstdio>
@@ -6,19 +7,22 @@
 #include "gmock/gmock.h"
 #include "../SSDManager/SSDWriter.cpp"
 #include "../SSDManager/FileManagerInterface.h"
+
 using namespace std;
 using namespace testing;
+
 class FileManagerWriterMock :public FileManagerInterface {
-public:
+ public:
     MOCK_METHOD(string, read, (string name), (override));
     MOCK_METHOD(string, read, (string name, int index), (override));
-    MOCK_METHOD(bool, write, (string name, int index, string value), (override));
+    MOCK_METHOD(bool, write, (string name, int index,
+                                           string value), (override));
     MOCK_METHOD(bool, write, (string name, string value), (override));
 };
 
 
 class SSDWriteTestFixture :public Test {
-public:
+ public:
     FileManagerWriterMock fm;
     SSDWriter ssd_writer{ &fm };
     string nand_file = "nand.txt";


### PR DESCRIPTION
## Context

cpplint is checked for below files :

- LogManager.cpp
- SSDEraser.cpp
- SSDWriter.cpp
- SSDReader.cpp
- SSDManager.cpp
- CommandBuffer.cpp
- main.cpp
- FileManager.h
- LogManager.h
- SSDEraser.h
- SSDWriter.h
- SSDReader.h
- SSDManager.h
- FileManager.h
- CommandBuffer.h
- FileManagerInterface.h
```
C:\Users\User\source\repos\SSDTestShell\SSDManager>cpplint .\LogManager.cpp
Done processing .\LogManager.cpp

C:\Users\User\source\repos\SSDTestShell\SSDManager>cpplint .\SSDEraser.cpp
Done processing .\SSDEraser.cpp

C:\Users\User\source\repos\SSDTestShell\SSDManager>cpplint .\SSDWriter.cpp
Done processing .\SSDWriter.cpp

C:\Users\User\source\repos\SSDTestShell\SSDManager>cpplint .\SSDReader.cpp
Done processing .\SSDReader.cpp

C:\Users\User\source\repos\SSDTestShell\SSDManager>cpplint .\SSDManager.cpp
Done processing .\SSDManager.cpp

C:\Users\User\source\repos\SSDTestShell\SSDManager>cpplint .\CommandBuffer.cpp
Done processing .\CommandBuffer.cpp

C:\Users\User\source\repos\SSDTestShell\SSDManager>cpplint .\main.cpp
Done processing .\main.cpp

C:\Users\User\source\repos\SSDTestShell\SSDManager>cpplint .\FileManager.h
Done processing .\FileManager.h

C:\Users\User\source\repos\SSDTestShell\SSDManager>cpplint .\LogManager.h
Done processing .\LogManager.h

C:\Users\User\source\repos\SSDTestShell\SSDManager>cpplint .\SSDEraser.h
Done processing .\SSDEraser.h

C:\Users\User\source\repos\SSDTestShell\SSDManager>cpplint .\SSDWriter.h
Done processing .\SSDWriter.h

C:\Users\User\source\repos\SSDTestShell\SSDManager>cpplint .\SSDReader.h
Done processing .\SSDReader.h

C:\Users\User\source\repos\SSDTestShell\SSDManager>cpplint .\SSDManager.h
Done processing .\SSDManager.h

C:\Users\User\source\repos\SSDTestShell\SSDManager>cpplint .\FileManager.h
Done processing .\FileManager.h

C:\Users\User\source\repos\SSDTestShell\SSDManager>cpplint .\CommandBuffer.h
Done processing .\CommandBuffer.h

C:\Users\User\source\repos\SSDTestShell\SSDManager>cpplint .\FileManagerInterface.h
```
- FileManagerTest.cpp
- SSDEraserTest.cpp
- SSDWriterTest.cpp
- SSDReaderTest.cpp
- SSDManagerTest.cpp
- CommandBufferTest.cpp
```
C:\Users\User\source\repos\SSDTestShell\SSDManagerTest>cpplint .\FileManagerTest.cpp
.\FileManagerTest.cpp:5:  Do not include .cpp files from other packages  [build/include] [4]
.\FileManagerTest.cpp:7:  Do not include .cpp files from other packages  [build/include] [4]
.\FileManagerTest.cpp:19:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces] [5]
.\FileManagerTest.cpp:20:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces] [5]
Done processing .\FileManagerTest.cpp
Total errors found: 4

C:\Users\User\source\repos\SSDTestShell\SSDManagerTest>cpplint .\SSDEraserTest.cpp
.\SSDEraserTest.cpp:7:  Do not include .cpp files from other packages  [build/include] [4]
.\SSDEraserTest.cpp:10:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces] [5]
.\SSDEraserTest.cpp:11:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces] [5]
Done processing .\SSDEraserTest.cpp
Total errors found: 3

C:\Users\User\source\repos\SSDTestShell\SSDManagerTest>cpplint .\SSDWriterTest.cpp
.\SSDWriterTest.cpp:8:  Do not include .cpp files from other packages  [build/include] [4]
.\SSDWriterTest.cpp:11:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces] [5]
.\SSDWriterTest.cpp:12:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces] [5]
Done processing .\SSDWriterTest.cpp
Total errors found: 3

C:\Users\User\source\repos\SSDTestShell\SSDManagerTest>cpplint .\SSDReaderTest.cpp
.\SSDReaderTest.cpp:7:  Do not include .cpp files from other packages  [build/include] [4]
.\SSDReaderTest.cpp:9:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces] [5]
.\SSDReaderTest.cpp:10:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces] [5]
Done processing .\SSDReaderTest.cpp
Total errors found: 3

C:\Users\User\source\repos\SSDTestShell\SSDManagerTest>cpplint .\SSDManagerTest.cpp
.\SSDManagerTest.cpp:5:  Do not include .cpp files from other packages  [build/include] [4]
.\SSDManagerTest.cpp:7:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces] [5]
Done processing .\SSDManagerTest.cpp
Total errors found: 2

C:\Users\User\source\repos\SSDTestShell\SSDManagerTest>cpplint .\CommandBufferTest.cpp
.\CommandBufferTest.cpp:6:  Do not include .cpp files from other packages  [build/include] [4]
Done processing .\CommandBufferTest.cpp
Total errors found: 1
```

## Test Result


- SSD Manager Test
 ```
[----------] Global test environment tear-down
[==========] 28 tests from 6 test suites ran. (1216 ms total)
[  PASSED  ] 28 tests.
```
- Test Shell Test
```
[----------] Global test environment tear-down
[==========] 14 tests from 1 test suite ran. (10620 ms total)
[  PASSED  ] 14 tests.
```